### PR TITLE
Add image identifier

### DIFF
--- a/dfdewey/__init__.py
+++ b/dfdewey/__init__.py
@@ -17,4 +17,4 @@
 dfDewey is a digital forensics string extraction, indexing, and searching tool.
 """
 
-__version__ = '20211019'
+__version__ = '20211109-dev'

--- a/dfdewey/utils/image_processor_test.py
+++ b/dfdewey/utils/image_processor_test.py
@@ -29,6 +29,7 @@ from dfdewey.utils.image_processor import (
 TEST_CASE = 'testcase'
 TEST_IMAGE = 'test.dd'
 TEST_IMAGE_HASH = 'd41d8cd98f00b204e9800998ecf8427e'
+TEST_IMAGE_ID = 'd41d8cd98f00b204e9800998ecf8427e'
 
 
 class FileEntryScannerTest(unittest.TestCase):
@@ -73,7 +74,7 @@ class ImageProcessorTest(unittest.TestCase):
     """
     image_processor_options = ImageProcessorOptions()
     image_processor = ImageProcessor(
-        TEST_CASE, TEST_IMAGE, image_processor_options)
+        TEST_CASE, TEST_IMAGE_ID, TEST_IMAGE, image_processor_options)
     image_processor.image_hash = TEST_IMAGE_HASH
     return image_processor
 
@@ -92,12 +93,12 @@ class ImageProcessorTest(unittest.TestCase):
     mock_initialise_database.assert_called_once()
     calls = [
         mock.call((
-            'INSERT INTO images (image_path, image_hash) '
-            'VALUES (\'{0:s}\', \'{1:s}\')').format(
-                TEST_IMAGE, TEST_IMAGE_HASH)),
+            'INSERT INTO images (image_id, image_path, image_hash) '
+            'VALUES (\'{0:s}\', \'{1:s}\', \'{2:s}\')').format(
+                TEST_IMAGE_ID, TEST_IMAGE, TEST_IMAGE_HASH)),
         mock.call((
-            'INSERT INTO image_case (case_id, image_hash) '
-            'VALUES (\'{0:s}\', \'{1:s}\')').format(TEST_CASE, TEST_IMAGE_HASH))
+            'INSERT INTO image_case (case_id, image_id) '
+            'VALUES (\'{0:s}\', \'{1:s}\')').format(TEST_CASE, TEST_IMAGE_ID))
     ]
     mock_postgresql.execute.assert_has_calls(calls)
     self.assertEqual(result, False)
@@ -118,8 +119,8 @@ class ImageProcessorTest(unittest.TestCase):
     image_processor.postgresql = mock_postgresql
     result = image_processor._already_parsed()
     mock_postgresql.execute.assert_called_once_with((
-        'INSERT INTO image_case (case_id, image_hash) '
-        'VALUES (\'{0:s}\', \'{1:s}\')').format(TEST_CASE, TEST_IMAGE_HASH))
+        'INSERT INTO image_case (case_id, image_id) '
+        'VALUES (\'{0:s}\', \'{1:s}\')').format(TEST_CASE, TEST_IMAGE_ID))
     self.assertEqual(result, True)
 
   @mock.patch('dfdewey.datastore.postgresql.PostgresqlDataStore')
@@ -266,12 +267,12 @@ class ImageProcessorTest(unittest.TestCase):
     image_processor.postgresql = mock_postgresql
     calls = [
         mock.call(
-            'CREATE TABLE images (image_path TEXT, image_hash TEXT PRIMARY KEY)'
+            'CREATE TABLE images (image_id TEXT PRIMARY KEY, image_path TEXT, image_hash TEXT)'
         ),
         mock.call((
             'CREATE TABLE image_case ('
-            'case_id TEXT, image_hash TEXT REFERENCES images(image_hash), '
-            'PRIMARY KEY (case_id, image_hash))'))
+            'case_id TEXT, image_id TEXT REFERENCES images(image_id), '
+            'PRIMARY KEY (case_id, image_id))'))
     ]
     image_processor._initialise_database()
     mock_postgresql.execute.assert_has_calls(calls)

--- a/dfdewey/utils/index_searcher.py
+++ b/dfdewey/utils/index_searcher.py
@@ -66,13 +66,14 @@ class _SearchHit():
 class IndexSearcher():
   """Index Searcher class."""
 
-  def __init__(self, case, image, config_file=None):
+  def __init__(self, case, image_id, image, config_file=None):
     """Create an index searcher."""
     super().__init__()
     self.case = case
     self.config = dfdewey_config.load_config(config_file)
     self.elasticsearch = None
     self.image = image
+    self.image_id = image_id
     self.images = {}
     self.postgresql = None
     self.scanner = None
@@ -204,8 +205,8 @@ class IndexSearcher():
       MD5 hash for the image stored in PostgreSQL.
     """
     image_hash = self.postgresql.query_single_row(
-        'SELECT image_hash FROM images WHERE image_path = \'{0:s}\''.format(
-            self.image))
+        'SELECT image_hash FROM images WHERE image_id = \'{0:s}\''.format(
+            self.image_id))
     if image_hash:
       self.images[image_hash[0]] = self.image
 

--- a/dfdewey/utils/index_searcher_test.py
+++ b/dfdewey/utils/index_searcher_test.py
@@ -26,6 +26,7 @@ from dfdewey.utils.index_searcher import IndexSearcher
 TEST_CASE = 'testcase'
 TEST_IMAGE = 'test.dd'
 TEST_IMAGE_HASH = 'd41d8cd98f00b204e9800998ecf8427e'
+TEST_IMAGE_ID = 'd41d8cd98f00b204e9800998ecf8427e'
 
 
 class IndexSearcherTest(unittest.TestCase):
@@ -41,7 +42,7 @@ class IndexSearcherTest(unittest.TestCase):
         'dfdewey.datastore.postgresql.PostgresqlDataStore.query_single_row'
     ) as mock_query_single_row:
       mock_query_single_row.return_value = (TEST_IMAGE_HASH,)
-      index_searcher = IndexSearcher(TEST_CASE, TEST_IMAGE)
+      index_searcher = IndexSearcher(TEST_CASE, TEST_IMAGE_ID, TEST_IMAGE)
     return index_searcher
 
   @mock.patch('dfdewey.datastore.postgresql.PostgresqlDataStore.query')
@@ -55,7 +56,7 @@ class IndexSearcherTest(unittest.TestCase):
         'image2.dd',
     )]
     with mock.patch('psycopg2.connect'):
-      index_searcher = IndexSearcher(TEST_CASE, 'all')
+      index_searcher = IndexSearcher(TEST_CASE, None, 'all')
     self.assertEqual(index_searcher.images['hash1'], 'image1.dd')
     self.assertEqual(index_searcher.images['hash2'], 'image2.dd')
 


### PR DESCRIPTION
Calculate an image identifier (MD5 of the first 2GB) for the image / disk being processed / searched.

Will add approximately 5 seconds to each run, but will differentiate images processed as a loopback device (as in Turbinia).

Fixes: #19 